### PR TITLE
Port rangeproof to dusk-crypto from dusk-blockchain

### DIFF
--- a/rangeproof/bitCommitment_test.go
+++ b/rangeproof/bitCommitment_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/dusk-network/dusk-crypto/rangeproof"
-
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rangeproof/debug.go
+++ b/rangeproof/debug.go
@@ -5,9 +5,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/dusk-network/dusk-crypto/rangeproof/vector"
-
 	ristretto "github.com/bwesterb/go-ristretto"
+	"github.com/dusk-network/dusk-crypto/rangeproof/vector"
 
 	"github.com/dusk-network/dusk-crypto/rangeproof/pedersen"
 )

--- a/rangeproof/generators/generator_test.go
+++ b/rangeproof/generators/generator_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	ristretto "github.com/bwesterb/go-ristretto"
-	"github.com/stretchr/testify/assert"
 	generator "github.com/dusk-network/dusk-crypto/rangeproof/generators"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGeneratorsLen(t *testing.T) {

--- a/rangeproof/innerproduct/innerproduct.go
+++ b/rangeproof/innerproduct/innerproduct.go
@@ -1,13 +1,15 @@
 package innerproduct
 
 import (
+	"bytes"
+	"encoding/binary"
 	"errors"
+	"io"
 	"math/bits"
 
+	ristretto "github.com/bwesterb/go-ristretto"
 	"github.com/dusk-network/dusk-crypto/rangeproof/fiatshamir"
 	"github.com/dusk-network/dusk-crypto/rangeproof/vector"
-
-	ristretto "github.com/bwesterb/go-ristretto"
 )
 
 // This is a reference of the innerProduct implementation at rust
@@ -23,6 +25,8 @@ type Proof struct {
 func Generate(GVec, HVec []ristretto.Point, aVec, bVec, HprimeFactors []ristretto.Scalar, Q ristretto.Point) (*Proof, error) {
 	n := uint32(len(GVec))
 
+	// XXX : When n is not a power of two, will the bulletproof struct pad it
+	// or will the inner product proof struct?
 	if !isPower2(uint32(n)) {
 		return nil, errors.New("[IPProof]: size of n (NM) is not a power of 2")
 	}
@@ -386,6 +390,105 @@ func (proof *Proof) Verify(G, H, L, R []ristretto.Point, HprimeFactor []ristrett
 	return have.Equals(&P)
 }
 
+func (p *Proof) Encode(w io.Writer) error {
+
+	err := binary.Write(w, binary.BigEndian, p.A.Bytes())
+	if err != nil {
+		return err
+	}
+	err = binary.Write(w, binary.BigEndian, p.B.Bytes())
+	if err != nil {
+		return err
+	}
+	lenL := uint32(len(p.L))
+
+	for i := uint32(0); i < lenL; i++ {
+		err = binary.Write(w, binary.BigEndian, p.L[i].Bytes())
+		if err != nil {
+			return err
+		}
+		err = binary.Write(w, binary.BigEndian, p.R[i].Bytes())
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *Proof) Decode(r io.Reader) error {
+	if p == nil {
+		return errors.New("struct is nil")
+	}
+
+	var ABytes, BBytes [32]byte
+	err := binary.Read(r, binary.BigEndian, &ABytes)
+	if err != nil {
+		return err
+	}
+	err = binary.Read(r, binary.BigEndian, &BBytes)
+	if err != nil {
+		return err
+	}
+	p.A.SetBytes(&ABytes)
+	p.B.SetBytes(&BBytes)
+
+	buf := &bytes.Buffer{}
+	_, err = buf.ReadFrom(r)
+	if err != nil {
+		return err
+	}
+	numBytes := len(buf.Bytes())
+	if numBytes%32 != 0 {
+		return errors.New("proof was not formatted correctly")
+	}
+	lenL := uint32(numBytes / 64)
+
+	p.L = make([]ristretto.Point, lenL)
+	p.R = make([]ristretto.Point, lenL)
+
+	for i := uint32(0); i < lenL; i++ {
+		var LBytes, RBytes [32]byte
+		err = binary.Read(buf, binary.BigEndian, &LBytes)
+		if err != nil {
+			return err
+		}
+		err = binary.Read(buf, binary.BigEndian, &RBytes)
+		if err != nil {
+			return err
+		}
+		p.L[i].SetBytes(&LBytes)
+		p.R[i].SetBytes(&RBytes)
+	}
+
+	return nil
+}
+
+func (p *Proof) Equals(other Proof) bool {
+	ok := p.A.Equals(&other.A)
+	if !ok {
+		return ok
+	}
+
+	ok = p.B.Equals(&other.B)
+	if !ok {
+		return ok
+	}
+
+	for i := range p.L {
+		ok := p.L[i].Equals(&other.L[i])
+		if !ok {
+			return ok
+		}
+
+		ok = p.R[i].Equals(&other.R[i])
+		if !ok {
+			return ok
+		}
+	}
+
+	return ok
+}
+
 func nextPow2(n uint) uint {
 	n--
 	n |= n >> 1
@@ -398,4 +501,10 @@ func nextPow2(n uint) uint {
 
 func isPower2(n uint32) bool {
 	return (n & (n - 1)) == 0
+}
+
+func DiffNextPow2(n uint32) uint32 {
+	pow2 := nextPow2(uint(n))
+	padAmount := uint32(pow2) - n + 1
+	return padAmount
 }

--- a/rangeproof/innerproduct/innerproduct_test.go
+++ b/rangeproof/innerproduct/innerproduct_test.go
@@ -1,12 +1,12 @@
 package innerproduct
 
 import (
+	"bytes"
 	"testing"
 
+	ristretto "github.com/bwesterb/go-ristretto"
 	"github.com/dusk-network/dusk-crypto/rangeproof/pedersen"
 	"github.com/dusk-network/dusk-crypto/rangeproof/vector"
-
-	ristretto "github.com/bwesterb/go-ristretto"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,7 +22,18 @@ func TestProofCreation(t *testing.T) {
 		assert.Equal(t, nil, err)
 
 		ok := proof.Verify(G, H, proof.L, proof.R, Hpf, Q, P, int(n))
-		assert.Equal(t, true, ok)
+		assert.True(t, ok)
+
+		buf := &bytes.Buffer{}
+
+		err = proof.Encode(buf)
+		assert.Equal(t, nil, err)
+
+		var decodedProof Proof
+		decodedProof.Decode(buf)
+		assert.Equal(t, nil, err)
+		ok = proof.Equals(decodedProof)
+		assert.True(t, ok)
 
 		n = n * 2
 	}

--- a/rangeproof/pedersen/pedersen.go
+++ b/rangeproof/pedersen/pedersen.go
@@ -1,9 +1,12 @@
 package pedersen
 
 import (
-	generator "github.com/dusk-network/dusk-crypto/rangeproof/generators"
+	"encoding/binary"
+	"errors"
+	"io"
 
 	ristretto "github.com/bwesterb/go-ristretto"
+	generator "github.com/dusk-network/dusk-crypto/rangeproof/generators"
 )
 
 // Pedersen represents a pedersen struct which holds
@@ -25,8 +28,8 @@ func New(genData []byte) *Pedersen {
 	var blindPoint ristretto.Point
 	var basePoint ristretto.Point
 
-	blindPoint.Derive([]byte("blindPoint"))
-	basePoint.SetBase()
+	basePoint.Derive([]byte("blindPoint"))
+	blindPoint.SetBase()
 
 	return &Pedersen{
 		BaseVector: gen,
@@ -44,6 +47,70 @@ type Commitment struct {
 	// blinding factor is the blinding scalar.
 	// Note that n vectors have 1 blinding factor
 	BlindingFactor ristretto.Scalar
+}
+
+func (c *Commitment) Encode(w io.Writer) error {
+	return binary.Write(w, binary.BigEndian, c.Value.Bytes())
+}
+
+func EncodeCommitments(w io.Writer, comms []Commitment) error {
+	lenV := uint32(len(comms))
+	err := binary.Write(w, binary.BigEndian, lenV)
+	if err != nil {
+		return err
+	}
+	for i := range comms {
+		err := comms[i].Encode(w)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Commitment) Decode(r io.Reader) error {
+	if c == nil {
+		return errors.New("struct is nil")
+	}
+
+	var cBytes [32]byte
+	err := binary.Read(r, binary.BigEndian, &cBytes)
+	if err != nil {
+		return err
+	}
+	ok := c.Value.SetBytes(&cBytes)
+	if !ok {
+		return errors.New("could not set bytes for commitment, not an encodable point")
+	}
+	return nil
+}
+
+func DecodeCommitments(r io.Reader) ([]Commitment, error) {
+
+	var lenV uint32
+	err := binary.Read(r, binary.BigEndian, &lenV)
+	if err != nil {
+		return nil, err
+	}
+
+	comms := make([]Commitment, lenV)
+
+	for i := uint32(0); i < lenV; i++ {
+		err := comms[i].Decode(r)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return comms, nil
+}
+
+func (c *Commitment) EqualValue(other Commitment) bool {
+	return c.Value.Equals(&other.Value)
+}
+
+func (c *Commitment) Equals(other Commitment) bool {
+	return c.EqualValue(other) && c.BlindingFactor.Equals(&other.BlindingFactor)
 }
 
 func (p *Pedersen) commitToScalars(blind *ristretto.Scalar, scalars ...ristretto.Scalar) ristretto.Point {

--- a/rangeproof/pedersen/pedersen_test.go
+++ b/rangeproof/pedersen/pedersen_test.go
@@ -1,12 +1,12 @@
 package pedersen_test
 
 import (
+	"bytes"
 	"math/big"
 	"testing"
 
-	"github.com/dusk-network/dusk-crypto/rangeproof/pedersen"
-
 	ristretto "github.com/bwesterb/go-ristretto"
+	"github.com/dusk-network/dusk-crypto/rangeproof/pedersen"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,6 +19,26 @@ func TestPedersenScalar(t *testing.T) {
 	commitment := ped.CommitToScalar(s)
 
 	assert.NotEqual(t, nil, commitment)
+
+}
+
+func TestEncodeDecode(t *testing.T) {
+	s := ristretto.Scalar{}
+	s.Rand()
+
+	c := pedersen.New([]byte("rand")).CommitToScalar(s)
+	assert.True(t, c.Equals(c))
+
+	buf := &bytes.Buffer{}
+	err := c.Encode(buf)
+	assert.Nil(t, err)
+
+	var decC pedersen.Commitment
+	err = decC.Decode(buf)
+	assert.Nil(t, err)
+
+	ok := decC.EqualValue(c)
+	assert.True(t, ok)
 
 }
 

--- a/rangeproof/poly.go
+++ b/rangeproof/poly.go
@@ -5,9 +5,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/dusk-network/dusk-crypto/rangeproof/vector"
-
 	ristretto "github.com/bwesterb/go-ristretto"
+	"github.com/dusk-network/dusk-crypto/rangeproof/vector"
 )
 
 // Polynomial construction
@@ -155,6 +154,8 @@ func (p *polynomial) computeT0(y, z ristretto.Scalar, v []ristretto.Scalar, n, m
 
 // calculates sum( z^(1+j) * ( 0^(j-1)n || 2 ^n || 0^(m-j)n ) ) from j = 1 to j=M (71)
 // implementation taken directly from java implementation.
+// XXX: Look into ways to speed this up, and improve readability
+// XXX: pass n and m as parameters
 func sumZMTwoN(z ristretto.Scalar) []ristretto.Scalar {
 
 	res := make([]ristretto.Scalar, N*M)

--- a/rangeproof/rangeproof.go
+++ b/rangeproof/rangeproof.go
@@ -1,37 +1,38 @@
 package rangeproof
 
 import (
+	"encoding/binary"
+	"fmt"
+	"io"
 	"math/big"
 
 	"github.com/pkg/errors"
 
+	ristretto "github.com/bwesterb/go-ristretto"
 	"github.com/dusk-network/dusk-crypto/rangeproof/fiatshamir"
 	"github.com/dusk-network/dusk-crypto/rangeproof/innerproduct"
 	"github.com/dusk-network/dusk-crypto/rangeproof/pedersen"
 	"github.com/dusk-network/dusk-crypto/rangeproof/vector"
-
-	ristretto "github.com/bwesterb/go-ristretto"
 )
 
 // N is number of bits in range
-// So amount will be between 0..2^(N-1)
+// So amount will be between 0...2^(N-1)
 const N = 64
 
-// M is the number of outputs
-// for one bulletproof
+// M is the number of outputs for one bulletproof
 var M = 1
 
-// M is the maximum number of outputs allowed
-// per bulletproof
-const maxM = 32
+// M is the maximum number of values allowed per rangeproof
+const maxM = 16
 
 // Proof is the constructed BulletProof
 type Proof struct {
-	V  []pedersen.Commitment // Curve points 32 bytes
-	A  ristretto.Point       // Curve point 32 bytes
-	S  ristretto.Point       // Curve point 32 bytes
-	T1 ristretto.Point       // Curve point 32 bytes
-	T2 ristretto.Point       // Curve point 32 bytes
+	V        []pedersen.Commitment // Curve points 32 bytes
+	Blinders []ristretto.Scalar
+	A        ristretto.Point // Curve point 32 bytes
+	S        ristretto.Point // Curve point 32 bytes
+	T1       ristretto.Point // Curve point 32 bytes
+	T2       ristretto.Point // Curve point 32 bytes
 
 	taux ristretto.Scalar //scalar
 	mu   ristretto.Scalar //scalar
@@ -40,8 +41,7 @@ type Proof struct {
 	IPProof *innerproduct.Proof
 }
 
-// Prove will take a scalar as a parameter and
-// using zero knowledge, prove that it is [0, 2^N)
+// Prove will take a set of scalars as a parameter and prove that it is [0, 2^N)
 func Prove(v []ristretto.Scalar, debug bool) (Proof, error) {
 
 	if len(v) < 1 {
@@ -49,6 +49,18 @@ func Prove(v []ristretto.Scalar, debug bool) (Proof, error) {
 	}
 
 	M = len(v)
+	if M > maxM {
+		return Proof{}, fmt.Errorf("maximum amount of values must be less than %d", maxM)
+	}
+
+	// Pad zero values until we have power of two
+	padAmount := innerproduct.DiffNextPow2(uint32(M))
+	M = M + int(padAmount)
+	for i := uint32(0); i < padAmount; i++ {
+		var zeroScalar ristretto.Scalar
+		zeroScalar.SetZero()
+		v = append(v, zeroScalar)
+	}
 
 	// commitment to values v
 	Vs := make([]pedersen.Commitment, 0, M)
@@ -307,8 +319,7 @@ func computeHprime(H []ristretto.Point, y ristretto.Scalar) []ristretto.Point {
 	return Hprimes
 }
 
-// Verify takes a bullet proof and
-// returns true only if the proof was valid
+// Verify takes a bullet proof and returns true only if the proof was valid
 func Verify(p Proof) (bool, error) {
 
 	genData := []byte("dusk.BulletProof.vec1")
@@ -475,8 +486,160 @@ func megacheckWithC(ipproof *innerproduct.Proof, mu, x, y, z, t, taux, w ristret
 
 	ok := zero.Equals(&sum)
 	if !ok {
-		return false, errors.New("Megacheck failed")
+		return false, errors.New("megacheck failed")
 	}
 
 	return true, nil
+}
+
+func (p *Proof) Encode(w io.Writer, includeCommits bool) error {
+
+	if includeCommits {
+		err := pedersen.EncodeCommitments(w, p.V)
+		if err != nil {
+			return err
+		}
+	}
+
+	err := binary.Write(w, binary.BigEndian, p.A.Bytes())
+	if err != nil {
+		return err
+	}
+	err = binary.Write(w, binary.BigEndian, p.S.Bytes())
+	if err != nil {
+		return err
+	}
+	err = binary.Write(w, binary.BigEndian, p.T1.Bytes())
+	if err != nil {
+		return err
+	}
+	err = binary.Write(w, binary.BigEndian, p.T2.Bytes())
+	if err != nil {
+		return err
+	}
+	err = binary.Write(w, binary.BigEndian, p.taux.Bytes())
+	if err != nil {
+		return err
+	}
+	err = binary.Write(w, binary.BigEndian, p.mu.Bytes())
+	if err != nil {
+		return err
+	}
+	err = binary.Write(w, binary.BigEndian, p.t.Bytes())
+	if err != nil {
+		return err
+	}
+	return p.IPProof.Encode(w)
+}
+
+func (p *Proof) Decode(r io.Reader, includeCommits bool) error {
+
+	if p == nil {
+		return errors.New("struct is nil")
+	}
+
+	if includeCommits {
+		comms, err := pedersen.DecodeCommitments(r)
+		if err != nil {
+			return err
+		}
+		p.V = comms
+	}
+
+	err := readerToPoint(r, &p.A)
+	if err != nil {
+		return err
+	}
+	err = readerToPoint(r, &p.S)
+	if err != nil {
+		return err
+	}
+	err = readerToPoint(r, &p.T1)
+	if err != nil {
+		return err
+	}
+	err = readerToPoint(r, &p.T2)
+	if err != nil {
+		return err
+	}
+	err = readerToScalar(r, &p.taux)
+	if err != nil {
+		return err
+	}
+	err = readerToScalar(r, &p.mu)
+	if err != nil {
+		return err
+	}
+	err = readerToScalar(r, &p.t)
+	if err != nil {
+		return err
+	}
+	p.IPProof = &innerproduct.Proof{}
+	return p.IPProof.Decode(r)
+}
+
+func (p *Proof) Equals(other Proof, includeCommits bool) bool {
+	if len(p.V) != len(other.V) && includeCommits {
+		return false
+	}
+
+	for i := range p.V {
+		ok := p.V[i].EqualValue(other.V[i])
+		if !ok {
+			return ok
+		}
+	}
+
+	ok := p.A.Equals(&other.A)
+	if !ok {
+		return ok
+	}
+	ok = p.S.Equals(&other.S)
+	if !ok {
+		return ok
+	}
+	ok = p.T1.Equals(&other.T1)
+	if !ok {
+		return ok
+	}
+	ok = p.T2.Equals(&other.T2)
+	if !ok {
+		return ok
+	}
+	ok = p.taux.Equals(&other.taux)
+	if !ok {
+		return ok
+	}
+	ok = p.mu.Equals(&other.mu)
+	if !ok {
+		return ok
+	}
+	ok = p.t.Equals(&other.t)
+	if !ok {
+		return ok
+	}
+	return true
+	return p.IPProof.Equals(*other.IPProof)
+}
+
+func readerToPoint(r io.Reader, p *ristretto.Point) error {
+	var x [32]byte
+	err := binary.Read(r, binary.BigEndian, &x)
+	if err != nil {
+		return err
+	}
+	ok := p.SetBytes(&x)
+	if !ok {
+		return errors.New("point not encodable")
+	}
+	return nil
+}
+func readerToScalar(r io.Reader, s *ristretto.Scalar) error {
+	var x [32]byte
+	err := binary.Read(r, binary.BigEndian, &x)
+	if err != nil {
+		return err
+	}
+	s.SetBytes(&x)
+	return nil
 }

--- a/rangeproof/rangeproof_test.go
+++ b/rangeproof/rangeproof_test.go
@@ -1,41 +1,41 @@
 package rangeproof
 
 import (
+	"bytes"
 	"math/big"
 	"math/rand"
 	"testing"
 
 	ristretto "github.com/bwesterb/go-ristretto"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestProveBulletProof(t *testing.T) {
 
-	// due to inner product proof, must be a multiple of two
-	m := 4
+	p := generateProof(3, t)
 
-	amounts := []ristretto.Scalar{}
-
-	for i := 0; i < m; i++ {
-
-		var amount ristretto.Scalar
-		n := rand.Int63()
-		amount.SetBigInt(big.NewInt(n))
-
-		amounts = append(amounts, amount)
-	}
-
-	// Prove
-	// t.Fail()
-	p, err := Prove(amounts, true)
-	if err != nil {
-		assert.FailNowf(t, err.Error(), "Prove function failed %s", "")
-	}
 	// Verify
-	ok, err := Verify(p)
+	ok, err := Verify(*p)
 	assert.Equal(t, nil, err)
 	assert.Equal(t, true, ok)
 
+}
+
+func TestEncodeDecode(t *testing.T) {
+	p := generateProof(4, t)
+	includeCommits := false
+
+	buf := &bytes.Buffer{}
+	err := p.Encode(buf, includeCommits)
+	assert.Nil(t, err)
+
+	var decodedProof Proof
+	err = decodedProof.Decode(buf, includeCommits)
+	assert.Nil(t, err)
+
+	ok := decodedProof.Equals(*p, includeCommits)
+	assert.True(t, ok)
 }
 
 func TestComputeMu(t *testing.T) {
@@ -52,6 +52,25 @@ func TestComputeMu(t *testing.T) {
 	assert.Equal(t, true, ok)
 }
 
+func generateProof(m int, t *testing.T) *Proof {
+
+	// XXX: m must be a multiple of two due to inner product proof
+	amounts := []ristretto.Scalar{}
+
+	for i := 0; i < m; i++ {
+
+		var amount ristretto.Scalar
+		n := rand.Int63()
+		amount.SetBigInt(big.NewInt(n))
+
+		amounts = append(amounts, amount)
+	}
+
+	// Prove
+	p, err := Prove(amounts, true)
+	require.Nil(t, err)
+	return &p
+}
 func BenchmarkProve(b *testing.B) {
 
 	var amount ristretto.Scalar
@@ -75,7 +94,6 @@ func BenchmarkVerify(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < 100; i++ {
-
 		// Verify
 		Verify(p)
 	}

--- a/rangeproof/vector/vector.go
+++ b/rangeproof/vector/vector.go
@@ -238,6 +238,8 @@ func SplitPoints(x []ristretto.Point, n uint32) ([]ristretto.Point, []ristretto.
 
 // SplitScalars will split a slice x using n
 // Result will be two slices a and b where a = [0,n) and b = [n, len(x))
+// Method same as above
+// XXX: use unit test to make sure they output same sizes
 func SplitScalars(x []ristretto.Scalar, n uint32) ([]ristretto.Scalar, []ristretto.Scalar, error) {
 	if len(x) <= 0 {
 		return nil, nil, errors.New("Original vector has length of zero")


### PR DESCRIPTION
* added support for bit commitment for Ristretto scalars aL and aR
* added Encode/Decode functionalities to the Proof struct
* added encoding/decoding functionalities to the Pedersen Commitment
* added padding, encode/decode of the rangeproof and Blinders array of Ristretto scalars